### PR TITLE
修复服务器列表只显示有模组服务器的bug

### DIFF
--- a/src/api/dstApi.js
+++ b/src/api/dstApi.js
@@ -1,3 +1,4 @@
+import { map } from "lodash";
 import { http } from "../utils/http";
 
 const dstHomeServerListUrl = "/api/dst/home/server"
@@ -26,32 +27,16 @@ async function getHomeListApi(params) {
 export async function dstHomeListApi(params) {
     const response = await getHomeListApi(params)
     const responseData = JSON.parse(response)
+    const fields = responseData.successinfo.fields
     const data = responseData.successinfo.data
-    const homelist = data.map(value => {
-        return {
-            __rowId: value[0],
-            clienthosted: value[1],
-            dedicated: value[2],
-            fo: value[3],
-            kleiofficial: value[4],
-            connected: value[5],
-            maxconnections: value[6],
-            intent: value[7],
-            mode: value[8],
-            mods: value[9],
-            name: value[10],
-            password: value[11],
-            platform: value[12],
-            pvp: value[13],
-            season: value[14],
-            clanonly: value[15],
-            steamclanid: value[16],
-            regionName: value[17],
-            countryCode: value[18],
-            isp: value[19],
-            region: value[20]
 
-        }
+    const homelist = data.map(value => {
+        const info = {}
+        fields.map((key, index) => {
+            info[key] = value[index]
+            return key
+        })
+        return info
     })
     const temp = {
         data: homelist,

--- a/src/api/dstApi.js
+++ b/src/api/dstApi.js
@@ -14,7 +14,7 @@ async function getHomeListApi(params) {
         sort_way: 1,
         search_type: 1,
         search_content: params.name,
-        mod: 1
+        mod: params.mods
     }, {
         headers: {
             'X-Requested-With': 'XMLHttpRequest'
@@ -24,7 +24,7 @@ async function getHomeListApi(params) {
 }
 
 export async function dstHomeListApi(params) {
-    const response =  await getHomeListApi(params)
+    const response = await getHomeListApi(params)
     const responseData = JSON.parse(response)
     const data = responseData.successinfo.data
     const homelist = data.map(value => {
@@ -62,7 +62,7 @@ export async function dstHomeListApi(params) {
         last_page: responseData.successinfo.last_page,
         fetch_time_delta: responseData.successinfo.fetch_time_delta
     }
-    
+
     return temp
 }
 
@@ -82,7 +82,7 @@ export async function dstHomeDetailApi(params) {
 
 export function getPlayer(response) {
     const success = response.success
-    if(!success) {
+    if (!success) {
         return []
     }
     return response.successinfo.players

--- a/src/pages/DstServerList/index.js
+++ b/src/pages/DstServerList/index.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-unused-vars */
 
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 
-import {ProTable} from '@ant-design/pro-components';
-import {Container, Box} from '@mui/material';
-import {Button, Modal, Image, Skeleton, Card} from 'antd';
-import {dstHomeListApi, dstHomeDetailApi} from '../../api/dstApi';
+import { ProTable } from '@ant-design/pro-components';
+import { Container, Box } from '@mui/material';
+import { Button, Modal, Image, Skeleton, Card } from 'antd';
+import { dstHomeListApi, dstHomeDetailApi } from '../../api/dstApi';
 
 import HomeDetail from './home';
 
@@ -51,7 +51,7 @@ const DstServerList = () => {
         }).then(response => {
             setLoading(false)
             const responseData = JSON.parse(response)
-            const {success} = responseData
+            const { success } = responseData
             if (success) {
                 setHomeInfo(responseData)
                 console.log(responseData.successinfo.players)
@@ -168,6 +168,46 @@ const DstServerList = () => {
             </div>),
         },
         {
+            disable: true,
+            title: '模组',
+            key: 'mods',
+            dataIndex: 'mods',
+            filters: true,
+            onFilter: true,
+            ellipsis: true,
+            valueType: 'select',
+            valueEnum: {
+                "": {
+                    key: '1115',
+                    text: '任意',
+                    status: '',
+                },
+                "0": {
+                    key: '1113',
+                    text: '无模组',
+                    status: '0',
+                },
+                "1": {
+                    key: '1114',
+                    text: '有模组',
+                    status: '1',
+                },
+
+            },
+            // eslint-disable-next-line no-unused-vars
+            render: (text, record, _, action) => (<div>
+                {record.mods === 1 && (
+                    <Image
+                        preview={false}
+                        width={28}
+                        src="https://dst.liuyh.com/static/img/dstui/icon/mods.png"
+                    />
+
+                    // <LockOutlined />
+                )}
+            </div>),
+        },
+        {
             title: '操作',
             valueType: 'option',
             key: 'option',
@@ -201,13 +241,13 @@ const DstServerList = () => {
                         }
 
                         }>
-                        <HomeDetail home={homeInfo}/>
+                        <HomeDetail home={homeInfo} />
                     </div>
                 </Skeleton>
             </Modal>
 
             <Container maxWidth="xl">
-                <Box sx={{p: 0, pb: 0}} dir="ltr">
+                <Box sx={{ p: 0, pb: 0 }} dir="ltr">
                     <ProTable
                         columns={columns}
                         cardBordered
@@ -258,7 +298,7 @@ const DstServerList = () => {
                             type: 'radio',
                             ...rowSelection
                         }}
-                        tableAlertRender={({selectedRowKeys, selectedRows, onCleanSelected}) => false}
+                        tableAlertRender={({ selectedRowKeys, selectedRows, onCleanSelected }) => false}
                     />
                 </Box>
             </Container>


### PR DESCRIPTION
- 新增有无模组过滤
- 优化服务器列表api获取后的处理

我自己的版本中将`src\setupProxy.js`等设置的url改到了`.env`文件中以隔离生产环境及保护隐私，如有需要我可以一起合并过来